### PR TITLE
Add lobbySpam event

### DIFF
--- a/draw_bot.py
+++ b/draw_bot.py
@@ -116,6 +116,13 @@ def on_chat(data):
     else:
         print(f"{data['id']} wrote > {data['message']}")
 
+@sio.on('lobbySpam')
+def on_lobbySpam():
+    """
+    When our chat messages get detected as spam and get blocked
+    """
+    print(f"Spam detected! You're sending too many messages.")
+
 @sio.on('lobbyPlayerConnected')
 def on_lobbyPlayerConnected(data):
     """


### PR DESCRIPTION
This will add listening for the lobbySpam event.

Currently, if the bot spams the chat (somehow), and its chat messages get blocked, it won't get logged to the console, which might be unhandy for debugging purposes.

My edit will print "Spam detected! You're sending too many messages.", just like how it's displayed in-game.